### PR TITLE
feat: procedural terrain with per-biome personality

### DIFF
--- a/src/canvas/SceneManager.tsx
+++ b/src/canvas/SceneManager.tsx
@@ -6,6 +6,8 @@ import { createTrigCurve2 } from '@/track/curves/TrigCurve2'
 import TrackMesh from '@/track/TrackMesh'
 import CoasterCamera from '@/track/CoasterCamera'
 import BiomeEnvironment from '@/levels/environments/BiomeEnvironment'
+import { TerrainContext } from '@/levels/environments/TerrainContext'
+import { createHeightFunction, sampleTrackPath } from '@/utils/terrainNoise'
 import BulletPool from '@/combat/projectiles/BulletPool'
 import EnemySpawner from '@/entities/spawning/EnemySpawner'
 import ShootingController from './ShootingController'
@@ -63,6 +65,9 @@ function LevelScene({ levelId }: { levelId: string }) {
     return factory(track.varA, track.varB, track.varC, track.scalar)
   }, [track])
 
+  const trackSamples = useMemo(() => sampleTrackPath((t) => curve.getPointAt(t)), [curve])
+  const heightFn = useMemo(() => createHeightFunction(biome, trackSamples), [biome, trackSamples])
+
   const color1 = useMemo(() => hexToRgb(track.color1), [track.color1])
   const color2 = useMemo(() => hexToRgb(track.color2), [track.color2])
 
@@ -71,7 +76,7 @@ function LevelScene({ levelId }: { levelId: string }) {
   const bulletSize = levelId === 'level4' ? 40 : 10
 
   return (
-    <>
+    <TerrainContext.Provider value={heightFn}>
       <CoasterCamera
         curve={curve}
         rollerSpeed={track.rollerSpeed}
@@ -101,7 +106,7 @@ function LevelScene({ levelId }: { levelId: string }) {
         <Vignette eskil={false} offset={0.1} darkness={0.4} />
         <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
       </EffectComposer>
-    </>
+    </TerrainContext.Provider>
   )
 }
 

--- a/src/levels/environments/BiomeDecorations.tsx
+++ b/src/levels/environments/BiomeDecorations.tsx
@@ -1,0 +1,407 @@
+import { useMemo, useCallback, useEffect } from 'react'
+import * as THREE from 'three'
+import type { BiomeType } from '@/types/level'
+import type { HeightFunction } from '@/utils/terrainNoise'
+
+interface BiomeDecorationsProps {
+  biome: BiomeType
+  heightFn: HeightFunction
+}
+
+/** Scatter positions in an annular ring, rejecting steep slopes */
+function scatterPositions(
+  count: number,
+  minR: number,
+  maxR: number,
+  heightFn: HeightFunction,
+  maxSlope = Math.PI / 4,
+): { x: number; y: number; z: number }[] {
+  const arr: { x: number; y: number; z: number }[] = []
+  let attempts = 0
+  while (arr.length < count && attempts < count * 5) {
+    attempts++
+    const r = minR + Math.random() * (maxR - minR)
+    const theta = Math.random() * Math.PI * 2
+    const x = Math.cos(theta) * r
+    const z = Math.sin(theta) * r
+    const y = heightFn(x, z)
+
+    // Simple slope check
+    const delta = 5
+    const hx = heightFn(x + delta, z)
+    const hz = heightFn(x, z + delta)
+    const dx = (hx - y) / delta
+    const dz = (hz - y) / delta
+    const slope = Math.atan(Math.sqrt(dx * dx + dz * dz))
+    if (slope > maxSlope) continue
+
+    arr.push({ x, y, z })
+  }
+  return arr
+}
+
+export default function BiomeDecorations({ biome, heightFn }: BiomeDecorationsProps) {
+  switch (biome) {
+    case 'desert':
+      return <DesertDecorations heightFn={heightFn} />
+    case 'ocean':
+      return <OceanDecorations heightFn={heightFn} />
+    case 'arctic':
+      return <ArcticDecorations heightFn={heightFn} />
+    default:
+      return null
+  }
+}
+
+// --- DESERT ---
+
+function DesertDecorations({ heightFn }: { heightFn: HeightFunction }) {
+  // Cacti
+  const cactiPositions = useMemo(() => scatterPositions(100, 400, 2800, heightFn), [heightFn])
+  const cactiGeo = useMemo(() => new THREE.CylinderGeometry(1.5, 2, 1, 6), [])
+  const cactiMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#2d6b1e', flatShading: true }), [])
+
+  const setCactiRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const scale = new THREE.Vector3()
+    for (let i = 0; i < cactiPositions.length; i++) {
+      const p = cactiPositions[i]
+      const h = 8 + Math.random() * 20
+      mat.makeTranslation(p.x, p.y + h / 2, p.z)
+      scale.set(1, h, 1)
+      mat.scale(scale)
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [cactiPositions])
+
+  // Rocks
+  const rockPositions = useMemo(() => scatterPositions(60, 300, 2800, heightFn), [heightFn])
+  const rockGeo = useMemo(() => new THREE.DodecahedronGeometry(1, 0), [])
+  const rockMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#8b6b4a', flatShading: true }), [])
+
+  const setRockRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const scale = new THREE.Vector3()
+    const q = new THREE.Quaternion()
+    const euler = new THREE.Euler()
+    for (let i = 0; i < rockPositions.length; i++) {
+      const p = rockPositions[i]
+      const s = 3 + Math.random() * 10
+      euler.set(Math.random() * 0.5, Math.random() * Math.PI * 2, Math.random() * 0.5)
+      q.setFromEuler(euler)
+      mat.compose(
+        new THREE.Vector3(p.x, p.y + s * 0.4, p.z),
+        q,
+        new THREE.Vector3(s, s * 0.6, s),
+      )
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [rockPositions])
+
+  // Tumbleweeds
+  const tumbleweedPositions = useMemo(() => scatterPositions(30, 200, 2500, heightFn), [heightFn])
+  const twGeo = useMemo(() => new THREE.IcosahedronGeometry(1, 0), [])
+  const twMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#9a8a5a', flatShading: true }), [])
+
+  const setTwRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    for (let i = 0; i < tumbleweedPositions.length; i++) {
+      const p = tumbleweedPositions[i]
+      const s = 2 + Math.random() * 4
+      mat.makeTranslation(p.x, p.y + s, p.z)
+      mat.scale(new THREE.Vector3(s, s, s))
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [tumbleweedPositions])
+
+  // Bone clusters
+  const bonePositions = useMemo(() => scatterPositions(15, 500, 2500, heightFn), [heightFn])
+  const boneGeo = useMemo(() => new THREE.CylinderGeometry(0.3, 0.5, 1, 4), [])
+  const boneMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#e8dcc8', flatShading: true }), [])
+
+  const setBoneRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const q = new THREE.Quaternion()
+    const euler = new THREE.Euler()
+    for (let i = 0; i < bonePositions.length; i++) {
+      const p = bonePositions[i]
+      euler.set(Math.random() * Math.PI, Math.random() * Math.PI, 0)
+      q.setFromEuler(euler)
+      mat.compose(
+        new THREE.Vector3(p.x, p.y + 1, p.z),
+        q,
+        new THREE.Vector3(2, 6 + Math.random() * 4, 2),
+      )
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [bonePositions])
+
+  useEffect(() => {
+    return () => {
+      cactiGeo.dispose(); cactiMat.dispose()
+      rockGeo.dispose(); rockMat.dispose()
+      twGeo.dispose(); twMat.dispose()
+      boneGeo.dispose(); boneMat.dispose()
+    }
+  }, [cactiGeo, cactiMat, rockGeo, rockMat, twGeo, twMat, boneGeo, boneMat])
+
+  return (
+    <>
+      <instancedMesh ref={setCactiRef} args={[cactiGeo, cactiMat, cactiPositions.length]} frustumCulled />
+      <instancedMesh ref={setRockRef} args={[rockGeo, rockMat, rockPositions.length]} frustumCulled />
+      <instancedMesh ref={setTwRef} args={[twGeo, twMat, tumbleweedPositions.length]} frustumCulled />
+      <instancedMesh ref={setBoneRef} args={[boneGeo, boneMat, bonePositions.length]} frustumCulled />
+    </>
+  )
+}
+
+// --- OCEAN ---
+
+function OceanDecorations({ heightFn }: { heightFn: HeightFunction }) {
+  // Rock pillars rising from seafloor
+  const pillarPositions = useMemo(() => scatterPositions(40, 600, 2800, heightFn, Math.PI / 2), [heightFn])
+  const pillarGeo = useMemo(() => new THREE.CylinderGeometry(3, 6, 1, 5), [])
+  const pillarMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#4a4a40', flatShading: true }), [])
+
+  const setPillarRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const scale = new THREE.Vector3()
+    for (let i = 0; i < pillarPositions.length; i++) {
+      const p = pillarPositions[i]
+      const h = 20 + Math.random() * 60
+      mat.makeTranslation(p.x, p.y + h / 2, p.z)
+      scale.set(1 + Math.random() * 0.5, h, 1 + Math.random() * 0.5)
+      mat.scale(scale)
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [pillarPositions])
+
+  // Coral clusters
+  const coralPositions = useMemo(() => {
+    // Only place coral underwater
+    return scatterPositions(60, 300, 2500, heightFn, Math.PI / 2)
+      .filter(p => p.y < 0)
+  }, [heightFn])
+  const coralGeo = useMemo(() => new THREE.SphereGeometry(1, 5, 4), [])
+  const coralMat = useMemo(() => new THREE.MeshPhongMaterial({ flatShading: true, vertexColors: true }), [])
+
+  const coralColors = useMemo(() => {
+    const n = coralPositions.length
+    const attr = new THREE.InstancedBufferAttribute(new Float32Array(n * 3), 3)
+    const palette = [
+      new THREE.Color('#ff4466'), new THREE.Color('#ff8844'),
+      new THREE.Color('#ffaa22'), new THREE.Color('#ff66aa'),
+      new THREE.Color('#aa44ff'), new THREE.Color('#44aaff'),
+    ]
+    for (let i = 0; i < n; i++) {
+      const c = palette[Math.floor(Math.random() * palette.length)]
+      attr.setXYZ(i, c.r, c.g, c.b)
+    }
+    return attr
+  }, [coralPositions])
+
+  const setCoralRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    mesh.instanceColor = coralColors
+    const mat = new THREE.Matrix4()
+    for (let i = 0; i < coralPositions.length; i++) {
+      const p = coralPositions[i]
+      const s = 3 + Math.random() * 8
+      mat.makeTranslation(p.x, p.y + s * 0.5, p.z)
+      mat.scale(new THREE.Vector3(s, s * (0.5 + Math.random() * 0.8), s))
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [coralPositions, coralColors])
+
+  // Seaweed strands
+  const seaweedPositions = useMemo(() => {
+    return scatterPositions(80, 200, 2500, heightFn, Math.PI / 2)
+      .filter(p => p.y < -5)
+  }, [heightFn])
+  const swGeo = useMemo(() => new THREE.CylinderGeometry(0.3, 0.5, 1, 4), [])
+  const swMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#1a6630', flatShading: true }), [])
+
+  const setSwRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const q = new THREE.Quaternion()
+    const euler = new THREE.Euler()
+    for (let i = 0; i < seaweedPositions.length; i++) {
+      const p = seaweedPositions[i]
+      const h = 8 + Math.random() * 25
+      euler.set(Math.random() * 0.15, 0, Math.random() * 0.15)
+      q.setFromEuler(euler)
+      mat.compose(
+        new THREE.Vector3(p.x, p.y + h / 2, p.z),
+        q,
+        new THREE.Vector3(1, h, 1),
+      )
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [seaweedPositions])
+
+  // Distant island landmarks (large rocks above water)
+  const islandPositions = useMemo(() => {
+    const arr: { x: number; y: number; z: number }[] = []
+    for (let i = 0; i < 5; i++) {
+      const theta = (i / 5) * Math.PI * 2 + Math.random() * 0.5
+      const r = 1800 + Math.random() * 800
+      const x = Math.cos(theta) * r
+      const z = Math.sin(theta) * r
+      const y = heightFn(x, z)
+      arr.push({ x, y: Math.max(y, 0), z })
+    }
+    return arr
+  }, [heightFn])
+  const islandGeo = useMemo(() => new THREE.DodecahedronGeometry(1, 1), [])
+  const islandMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#5a5a4a', flatShading: true }), [])
+
+  const setIslandRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    for (let i = 0; i < islandPositions.length; i++) {
+      const p = islandPositions[i]
+      const s = 30 + Math.random() * 50
+      mat.makeTranslation(p.x, p.y + s * 0.3, p.z)
+      mat.scale(new THREE.Vector3(s, s * 0.7, s))
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [islandPositions])
+
+  useEffect(() => {
+    return () => {
+      pillarGeo.dispose(); pillarMat.dispose()
+      coralGeo.dispose(); coralMat.dispose()
+      swGeo.dispose(); swMat.dispose()
+      islandGeo.dispose(); islandMat.dispose()
+    }
+  }, [pillarGeo, pillarMat, coralGeo, coralMat, swGeo, swMat, islandGeo, islandMat])
+
+  return (
+    <>
+      <instancedMesh ref={setPillarRef} args={[pillarGeo, pillarMat, pillarPositions.length]} frustumCulled />
+      {coralPositions.length > 0 && (
+        <instancedMesh ref={setCoralRef} args={[coralGeo, coralMat, coralPositions.length]} frustumCulled />
+      )}
+      {seaweedPositions.length > 0 && (
+        <instancedMesh ref={setSwRef} args={[swGeo, swMat, seaweedPositions.length]} frustumCulled />
+      )}
+      <instancedMesh ref={setIslandRef} args={[islandGeo, islandMat, islandPositions.length]} frustumCulled />
+    </>
+  )
+}
+
+// --- ARCTIC ---
+
+function ArcticDecorations({ heightFn }: { heightFn: HeightFunction }) {
+  // Ice crystal shards (stretched octahedrons)
+  const crystalPositions = useMemo(() => scatterPositions(100, 400, 3500, heightFn), [heightFn])
+  const crystalGeo = useMemo(() => new THREE.OctahedronGeometry(1, 0), [])
+  const crystalMat = useMemo(() => new THREE.MeshPhongMaterial({
+    color: '#a0d0f0',
+    emissive: '#203040',
+    emissiveIntensity: 0.3,
+    flatShading: true,
+    transparent: true,
+    opacity: 0.85,
+  }), [])
+
+  const setCrystalRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const q = new THREE.Quaternion()
+    const euler = new THREE.Euler()
+    for (let i = 0; i < crystalPositions.length; i++) {
+      const p = crystalPositions[i]
+      const h = 5 + Math.random() * 20
+      euler.set(Math.random() * 0.3, Math.random() * Math.PI * 2, Math.random() * 0.3)
+      q.setFromEuler(euler)
+      mat.compose(
+        new THREE.Vector3(p.x, p.y + h * 0.5, p.z),
+        q,
+        new THREE.Vector3(2 + Math.random() * 3, h, 2 + Math.random() * 3),
+      )
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [crystalPositions])
+
+  // Snow-covered boulders
+  const boulderPositions = useMemo(() => scatterPositions(60, 300, 3500, heightFn), [heightFn])
+  const boulderGeo = useMemo(() => new THREE.DodecahedronGeometry(1, 0), [])
+  const boulderMat = useMemo(() => new THREE.MeshPhongMaterial({ color: '#d8e0e8', flatShading: true }), [])
+
+  const setBoulderRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const q = new THREE.Quaternion()
+    const euler = new THREE.Euler()
+    for (let i = 0; i < boulderPositions.length; i++) {
+      const p = boulderPositions[i]
+      const s = 4 + Math.random() * 12
+      euler.set(Math.random() * 0.5, Math.random() * Math.PI * 2, Math.random() * 0.5)
+      q.setFromEuler(euler)
+      mat.compose(
+        new THREE.Vector3(p.x, p.y + s * 0.3, p.z),
+        q,
+        new THREE.Vector3(s, s * 0.7, s),
+      )
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [boulderPositions])
+
+  // Tall ice columns (semi-transparent)
+  const columnPositions = useMemo(() => scatterPositions(30, 600, 4000, heightFn), [heightFn])
+  const columnGeo = useMemo(() => new THREE.CylinderGeometry(2, 4, 1, 6), [])
+  const columnMat = useMemo(() => new THREE.MeshPhongMaterial({
+    color: '#b0d8f0',
+    flatShading: true,
+    transparent: true,
+    opacity: 0.7,
+  }), [])
+
+  const setColumnRef = useCallback((mesh: THREE.InstancedMesh | null) => {
+    if (!mesh) return
+    const mat = new THREE.Matrix4()
+    const scale = new THREE.Vector3()
+    for (let i = 0; i < columnPositions.length; i++) {
+      const p = columnPositions[i]
+      const h = 30 + Math.random() * 60
+      mat.makeTranslation(p.x, p.y + h / 2, p.z)
+      scale.set(1, h, 1)
+      mat.scale(scale)
+      mesh.setMatrixAt(i, mat)
+    }
+    mesh.instanceMatrix.needsUpdate = true
+  }, [columnPositions])
+
+  useEffect(() => {
+    return () => {
+      crystalGeo.dispose(); crystalMat.dispose()
+      boulderGeo.dispose(); boulderMat.dispose()
+      columnGeo.dispose(); columnMat.dispose()
+    }
+  }, [crystalGeo, crystalMat, boulderGeo, boulderMat, columnGeo, columnMat])
+
+  return (
+    <>
+      <instancedMesh ref={setCrystalRef} args={[crystalGeo, crystalMat, crystalPositions.length]} frustumCulled />
+      <instancedMesh ref={setBoulderRef} args={[boulderGeo, boulderMat, boulderPositions.length]} frustumCulled />
+      <instancedMesh ref={setColumnRef} args={[columnGeo, columnMat, columnPositions.length]} frustumCulled />
+    </>
+  )
+}

--- a/src/levels/environments/BiomeEnvironment.tsx
+++ b/src/levels/environments/BiomeEnvironment.tsx
@@ -1,7 +1,10 @@
-import { useMemo, useRef, useCallback } from 'react'
+import { useMemo, useRef, useCallback, useEffect, useContext } from 'react'
 import * as THREE from 'three'
 import { Sky } from '@react-three/drei'
 import type { BiomeType } from '@/types/level'
+import { createHeightFunction, getTerrainSlope, type HeightFunction } from '@/utils/terrainNoise'
+import { TerrainContext } from './TerrainContext'
+import BiomeDecorations from './BiomeDecorations'
 import FerrisWheel from './FerrisWheel'
 import Carousel from './Carousel'
 
@@ -24,7 +27,6 @@ const BIOME_SETTINGS: Record<
     fogColor: number
     fogNear: number
     fogFar: number
-    displaceGround: boolean
   }
 > = {
   themePark: {
@@ -34,8 +36,7 @@ const BIOME_SETTINGS: Record<
     dirIntensity: 1.2,
     fogColor: 0x202020,
     fogNear: 1,
-    fogFar: 4000,
-    displaceGround: true,
+    fogFar: 5000,
   },
   desert: {
     sunPosition: [200, 150, -50],
@@ -45,7 +46,6 @@ const BIOME_SETTINGS: Record<
     fogColor: 0xd2a679,
     fogNear: 100,
     fogFar: 6000,
-    displaceGround: false,
   },
   ocean: {
     sunPosition: [50, 100, 200],
@@ -55,7 +55,6 @@ const BIOME_SETTINGS: Record<
     fogColor: 0x4a7d7c,
     fogNear: 100,
     fogFar: 5800,
-    displaceGround: false,
   },
   arctic: {
     sunPosition: [100, 50, 100],
@@ -64,49 +63,143 @@ const BIOME_SETTINGS: Record<
     dirIntensity: 0.9,
     fogColor: 0xd0d8ea,
     fogNear: 1,
-    fogFar: 4000,
-    displaceGround: false,
+    fogFar: 5500,
   },
 }
 
+// --- Vertex color ramps per biome ---
+
+interface ColorStop {
+  height: number // normalized height 0-1
+  color: THREE.Color
+}
+
+const BIOME_COLOR_RAMPS: Record<BiomeType, { stops: ColorStop[]; cliffColor: THREE.Color }> = {
+  themePark: {
+    stops: [
+      { height: 0.0, color: new THREE.Color(0x2d5a1e) },  // dark green valley
+      { height: 0.25, color: new THREE.Color(0x3a7a28) }, // green hills
+      { height: 0.5, color: new THREE.Color(0x6b8a3a) },  // light green
+      { height: 0.7, color: new THREE.Color(0x8b7355) },  // brown rock
+      { height: 0.85, color: new THREE.Color(0x999088) }, // grey rock
+      { height: 1.0, color: new THREE.Color(0xf0f0f0) },  // snow caps
+    ],
+    cliffColor: new THREE.Color(0x6b5a4a),
+  },
+  desert: {
+    stops: [
+      { height: 0.0, color: new THREE.Color(0xc2a060) },  // packed sand
+      { height: 0.3, color: new THREE.Color(0xd4b36a) },  // golden dunes
+      { height: 0.5, color: new THREE.Color(0xdaaa50) },  // deeper gold
+      { height: 0.7, color: new THREE.Color(0xb85a3a) },  // red rock
+      { height: 0.9, color: new THREE.Color(0x8b4030) },  // dark red mesa
+      { height: 1.0, color: new THREE.Color(0x7a3528) },  // mesa top
+    ],
+    cliffColor: new THREE.Color(0x7a4530),
+  },
+  ocean: {
+    stops: [
+      { height: 0.0, color: new THREE.Color(0x1a3a4a) },  // deep seafloor
+      { height: 0.2, color: new THREE.Color(0x2a5a5a) },  // mid seafloor
+      { height: 0.4, color: new THREE.Color(0x4a8a6a) },  // shallows
+      { height: 0.6, color: new THREE.Color(0x6aaa70) },  // near surface
+      { height: 0.75, color: new THREE.Color(0x5a5a50) }, // volcanic rock
+      { height: 1.0, color: new THREE.Color(0x3a3a35) },  // dark volcanic peak
+    ],
+    cliffColor: new THREE.Color(0x2a2a28),
+  },
+  arctic: {
+    stops: [
+      { height: 0.0, color: new THREE.Color(0x8ab4cc) },  // pale blue ice
+      { height: 0.2, color: new THREE.Color(0xc0d8e8) },  // light blue
+      { height: 0.4, color: new THREE.Color(0xe0e8f0) },  // white snow
+      { height: 0.6, color: new THREE.Color(0xf0f4f8) },  // bright snow
+      { height: 0.8, color: new THREE.Color(0xd0e0f0) },  // blue-white
+      { height: 1.0, color: new THREE.Color(0xa0c0e0) },  // blue ice peaks
+    ],
+    cliffColor: new THREE.Color(0x7090b0),
+  },
+}
+
+function sampleColorRamp(stops: ColorStop[], t: number, tmp: THREE.Color): void {
+  const clamped = Math.max(0, Math.min(1, t))
+  for (let i = 0; i < stops.length - 1; i++) {
+    if (clamped <= stops[i + 1].height) {
+      const range = stops[i + 1].height - stops[i].height
+      const localT = range > 0 ? (clamped - stops[i].height) / range : 0
+      tmp.copy(stops[i].color).lerp(stops[i + 1].color, localT)
+      return
+    }
+  }
+  tmp.copy(stops[stops.length - 1].color)
+}
+
 /**
- * Port of Poem.js ground generation with vertex displacement.
- * Original: vertices displaced by random * max(0, distance/5 - 250)
+ * Creates a noise-based terrain mesh with vertex coloring.
+ * 128x128 segments for chunky low-poly flat-shading aesthetic.
  */
-function createDisplacedGround(
-  width: number,
-  height: number,
-  wSeg: number,
-  hSeg: number,
+function createNoiseTerrain(
+  biome: BiomeType,
+  heightFn: HeightFunction,
+  size: number,
+  segments: number,
 ): THREE.BufferGeometry {
-  const geo = new THREE.PlaneGeometry(width, height, wSeg, hSeg)
+  const geo = new THREE.PlaneGeometry(size, size, segments, segments)
   geo.rotateX(-Math.PI / 2)
 
   const pos = geo.attributes.position
-  const center = new THREE.Vector3(0, 0, 0)
-  const v = new THREE.Vector3()
+  const ramp = BIOME_COLOR_RAMPS[biome]
 
+  // Get amplitude range for normalizing colors
+  // We sample a few heights to estimate max
+  let maxH = 1
   for (let i = 0; i < pos.count; i++) {
-    v.set(pos.getX(i), pos.getY(i), pos.getZ(i))
-
-    // Offset XZ randomly
-    const nx = v.x + (Math.random() * 100 - 50)
-    const nz = v.z + (Math.random() * 100 - 50)
-
-    // Height based on distance from center
-    const distance = v.distanceTo(center) / 5 - 250
-    const ny = Math.random() * Math.max(0, distance)
-
-    pos.setXYZ(i, nx, ny, nz)
+    const x = pos.getX(i)
+    const z = pos.getZ(i)
+    const y = heightFn(x, z)
+    pos.setY(i, y)
+    maxH = Math.max(maxH, Math.abs(y))
   }
 
+  // Compute vertex normals for slope detection
   geo.computeVertexNormals()
-  return geo
-}
+  const normals = geo.attributes.normal
 
-function createFlatGround(width: number, height: number): THREE.BufferGeometry {
-  const geo = new THREE.PlaneGeometry(width, height)
-  geo.rotateX(-Math.PI / 2)
+  // Create vertex colors
+  const colors = new Float32Array(pos.count * 3)
+  const tmp = new THREE.Color()
+  const upVec = new THREE.Vector3(0, 1, 0)
+  const normalVec = new THREE.Vector3()
+
+  for (let i = 0; i < pos.count; i++) {
+    const y = pos.getY(i)
+    // Normalize height to [0, 1] for color ramp
+    const normalizedH = Math.max(0, Math.min(1, Math.abs(y) / maxH))
+
+    // Get slope from vertex normal (dot with up)
+    normalVec.set(
+      normals.getX(i),
+      normals.getY(i),
+      normals.getZ(i),
+    )
+    const slopeDot = normalVec.dot(upVec) // 1 = flat, 0 = vertical
+    const slopeFactor = 1 - Math.max(0, Math.min(1, (1 - slopeDot) * 3)) // steep = 0
+
+    // Sample color ramp
+    sampleColorRamp(ramp.stops, normalizedH, tmp)
+
+    // Blend toward cliff color on steep slopes
+    if (slopeFactor < 1) {
+      tmp.lerp(ramp.cliffColor, 1 - slopeFactor)
+    }
+
+    colors[i * 3] = tmp.r
+    colors[i * 3 + 1] = tmp.g
+    colors[i * 3 + 2] = tmp.b
+  }
+
+  geo.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
+
   return geo
 }
 
@@ -119,17 +212,17 @@ export default function BiomeEnvironment({
   treeCount = 0,
 }: BiomeEnvironmentProps) {
   const settings = BIOME_SETTINGS[biome]
-  const groundColorObj = useMemo(() => new THREE.Color(groundColor), [groundColor])
   const fogColor = fog?.color ?? settings.fogColor
+  const heightFn = useContext(TerrainContext)
 
   const groundGeo = useMemo(() => {
-    if (settings.displaceGround) {
-      return createDisplacedGround(5000, 5000, 30, 30)
-    }
-    const w = biome === 'arctic' ? 10000 : 5000
-    const h = biome === 'arctic' ? 10000 : 5000
-    return createFlatGround(w, h)
-  }, [biome, settings.displaceGround])
+    const size = biome === 'arctic' ? 10000 : 6000
+    return createNoiseTerrain(biome, heightFn, size, 128)
+  }, [biome, heightFn])
+
+  useEffect(() => {
+    return () => groundGeo.dispose()
+  }, [groundGeo])
 
   return (
     <>
@@ -139,7 +232,7 @@ export default function BiomeEnvironment({
         sunPosition={settings.sunPosition}
       />
 
-      {/* Lighting — port of Poem.js: HemisphereLight + DirectionalLight */}
+      {/* Lighting */}
       <hemisphereLight args={[0xfff0f0, 0x606066, 1]} />
       <directionalLight position={[1, 1, 1]} intensity={0.5} />
 
@@ -149,15 +242,15 @@ export default function BiomeEnvironment({
         args={[fogColor, fog?.near ?? settings.fogNear, fog?.far ?? settings.fogFar]}
       />
 
-      {/* Ground */}
-      <mesh geometry={groundGeo} visible={!hasWater}>
-        <meshPhongMaterial color={groundColorObj} flatShading />
+      {/* Terrain mesh */}
+      <mesh geometry={groundGeo}>
+        <meshPhongMaterial vertexColors flatShading />
       </mesh>
 
       {/* Water (ocean level) */}
       {hasWater && (
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
-          <planeGeometry args={[5000, 5000]} />
+          <planeGeometry args={[6000, 6000]} />
           <meshPhongMaterial
             color={0x004f41}
             transparent
@@ -167,8 +260,13 @@ export default function BiomeEnvironment({
         </mesh>
       )}
 
-      {/* Trees for theme park */}
-      {hasTrees && treeCount > 0 && <TreeField count={treeCount} biome={biome} />}
+      {/* Trees */}
+      {hasTrees && treeCount > 0 && (
+        <TreeField count={treeCount} biome={biome} heightFn={heightFn} />
+      )}
+
+      {/* Biome-specific decorations */}
+      {biome !== 'themePark' && <BiomeDecorations biome={biome} heightFn={heightFn} />}
 
       {/* Funfair decorations for theme park */}
       {biome === 'themePark' && <FunfairDecorations />}
@@ -186,45 +284,227 @@ export default function BiomeEnvironment({
   )
 }
 
-/** Port of TreeField.js — random trees scattered around */
-function TreeField({ count, biome }: { count: number; biome: BiomeType }) {
+/** Parse HSL string to RGB for instance color attribute */
+function hslToRgb(hsl: string): [number, number, number] {
+  const c = new THREE.Color()
+  c.setStyle(hsl)
+  return [c.r, c.g, c.b]
+}
+
+// --- Tree configs per biome ---
+
+interface TreeTypeConfig {
+  trunkColor: string
+  canopyColors: () => string
+  canopyGeoFactory: () => THREE.BufferGeometry
+  heightRange: [number, number]
+}
+
+function getTreeTypes(biome: BiomeType): TreeTypeConfig[] {
+  switch (biome) {
+    case 'themePark':
+      return [
+        {
+          trunkColor: '#5c3a1e',
+          canopyColors: () => `hsl(${100 + Math.random() * 40}, ${50 + Math.random() * 30}%, ${25 + Math.random() * 20}%)`,
+          canopyGeoFactory: () => new THREE.ConeGeometry(1, 1, 6),
+          heightRange: [30, 90],
+        },
+        {
+          trunkColor: '#6b4422',
+          canopyColors: () => `hsl(${80 + Math.random() * 50}, ${40 + Math.random() * 30}%, ${20 + Math.random() * 25}%)`,
+          canopyGeoFactory: () => new THREE.DodecahedronGeometry(1, 1),
+          heightRange: [25, 70],
+        },
+      ]
+    case 'desert':
+      return [
+        {
+          trunkColor: '#8a7a5a',
+          canopyColors: () => `hsl(${30 + Math.random() * 20}, ${20 + Math.random() * 15}%, ${30 + Math.random() * 15}%)`,
+          canopyGeoFactory: () => new THREE.ConeGeometry(1, 1, 4),
+          heightRange: [15, 35],
+        },
+      ]
+    case 'arctic':
+      return [
+        {
+          trunkColor: '#6a6a6a',
+          canopyColors: () => `hsl(${180 + Math.random() * 30}, ${10 + Math.random() * 15}%, ${40 + Math.random() * 20}%)`,
+          canopyGeoFactory: () => new THREE.ConeGeometry(1, 1, 5),
+          heightRange: [20, 50],
+        },
+      ]
+    default:
+      return []
+  }
+}
+
+function getTreeCount(biome: BiomeType, requested: number): number {
+  switch (biome) {
+    case 'themePark': return requested // 120
+    case 'desert': return Math.min(15, requested)
+    case 'arctic': return Math.min(20, requested)
+    case 'ocean': return 0
+    default: return requested
+  }
+}
+
+/** Trees placed on terrain with slope rejection and biome variety */
+function TreeField({
+  count,
+  biome,
+  heightFn,
+}: {
+  count: number
+  biome: BiomeType
+  heightFn: HeightFunction
+}) {
+  const treeTypes = useMemo(() => getTreeTypes(biome), [biome])
+  const actualCount = getTreeCount(biome, count)
+
   const trees = useMemo(() => {
-    const arr: { x: number; y: number; z: number; height: number; color: string }[] = []
-    const minR = biome === 'themePark' ? 1200 : 300
-    for (let i = 0; i < count; i++) {
-      const r = minR + Math.random() * 2200
+    if (actualCount === 0 || treeTypes.length === 0) return []
+    const arr: { x: number; y: number; z: number; height: number; color: string; typeIdx: number }[] = []
+    const minR = biome === 'themePark' ? 800 : 300
+    const maxR = biome === 'themePark' ? 3000 : 2500
+    const maxSlopeAngle = Math.PI / 4 // 45 degrees
+
+    let attempts = 0
+    while (arr.length < actualCount && attempts < actualCount * 5) {
+      attempts++
+      const r = minR + Math.random() * (maxR - minR)
       const theta = Math.random() * Math.PI * 2
+      const x = Math.cos(theta) * r
+      const z = Math.sin(theta) * r
+
+      // Slope rejection
+      const slope = getTerrainSlope(heightFn, x, z)
+      if (slope > maxSlopeAngle) continue
+
+      const y = heightFn(x, z)
+
+      // Ocean: skip trees below water
+      if (biome === 'ocean' && y < 2) continue
+
+      const typeIdx = Math.floor(Math.random() * treeTypes.length)
+      const tType = treeTypes[typeIdx]
+      const height = tType.heightRange[0] + Math.random() * (tType.heightRange[1] - tType.heightRange[0])
+
       arr.push({
-        x: Math.cos(theta) * r,
-        y: 0,
-        z: Math.sin(theta) * r,
-        height: 30 + Math.random() * 60,
-        color: `hsl(${100 + Math.random() * 40}, ${50 + Math.random() * 30}%, ${25 + Math.random() * 20}%)`,
+        x,
+        y,
+        z,
+        height,
+        color: tType.canopyColors(),
+        typeIdx,
       })
     }
     return arr
-  }, [count, biome])
+  }, [actualCount, biome, heightFn, treeTypes])
 
-  // Use InstancedMesh for performance
-  const trunkGeo = useMemo(() => new THREE.CylinderGeometry(2, 4, 1, 6), [])
-  const canopyGeo = useMemo(() => new THREE.ConeGeometry(1, 1, 6), [])
+  // Group trees by type for instancing
+  const groupedTrees = useMemo(() => {
+    const groups: Map<number, typeof trees> = new Map()
+    for (const tree of trees) {
+      if (!groups.has(tree.typeIdx)) groups.set(tree.typeIdx, [])
+      groups.get(tree.typeIdx)!.push(tree)
+    }
+    return groups
+  }, [trees])
+
+  if (trees.length === 0) return null
 
   return (
     <>
-      {trees.map((tree, i) => (
-        <group key={i} position={[tree.x, tree.y, tree.z]}>
-          {/* Trunk */}
-          <mesh position={[0, tree.height * 0.3, 0]} scale={[1, tree.height * 0.6, 1]}>
-            <cylinderGeometry args={[2, 4, 1, 6]} />
-            <meshPhongMaterial color="#5c3a1e" flatShading />
-          </mesh>
-          {/* Canopy */}
-          <mesh position={[0, tree.height * 0.75, 0]} scale={[tree.height * 0.4, tree.height * 0.5, tree.height * 0.4]}>
-            <coneGeometry args={[1, 1, 6]} />
-            <meshPhongMaterial color={tree.color} flatShading />
-          </mesh>
-        </group>
+      {Array.from(groupedTrees.entries()).map(([typeIdx, group]) => (
+        <TreeTypeInstances
+          key={typeIdx}
+          trees={group}
+          treeType={treeTypes[typeIdx]}
+        />
       ))}
+    </>
+  )
+}
+
+function TreeTypeInstances({
+  trees,
+  treeType,
+}: {
+  trees: { x: number; y: number; z: number; height: number; color: string }[]
+  treeType: TreeTypeConfig
+}) {
+  const trunkGeo = useMemo(() => new THREE.CylinderGeometry(2, 4, 1, 6), [])
+  const canopyGeo = useMemo(() => treeType.canopyGeoFactory(), [treeType])
+
+  const trunkMat = useMemo(
+    () => new THREE.MeshPhongMaterial({ color: treeType.trunkColor, flatShading: true }),
+    [treeType],
+  )
+  const canopyMat = useMemo(
+    () => new THREE.MeshPhongMaterial({ flatShading: true, vertexColors: true }),
+    [],
+  )
+
+  const instanceColorAttr = useMemo(() => {
+    const n = trees.length
+    const attr = new THREE.InstancedBufferAttribute(new Float32Array(n * 3), 3)
+    for (let i = 0; i < n; i++) {
+      const [r, g, b] = hslToRgb(trees[i].color)
+      attr.setXYZ(i, r, g, b)
+    }
+    return attr
+  }, [trees])
+
+  const _mat = useRef(new THREE.Matrix4()).current
+  const _scale = useRef(new THREE.Vector3()).current
+
+  const setTrunkRef = useCallback(
+    (mesh: THREE.InstancedMesh | null) => {
+      if (!mesh) return
+      for (let i = 0; i < trees.length; i++) {
+        const t = trees[i]
+        _mat.makeTranslation(t.x, t.y + t.height * 0.3, t.z)
+        _scale.set(1, t.height * 0.6, 1)
+        _mat.scale(_scale)
+        mesh.setMatrixAt(i, _mat)
+      }
+      mesh.instanceMatrix.needsUpdate = true
+    },
+    [trees, _mat, _scale],
+  )
+
+  const setCanopyRef = useCallback(
+    (mesh: THREE.InstancedMesh | null) => {
+      if (!mesh) return
+      mesh.instanceColor = instanceColorAttr
+      for (let i = 0; i < trees.length; i++) {
+        const t = trees[i]
+        _mat.makeTranslation(t.x, t.y + t.height * 0.75, t.z)
+        _scale.set(t.height * 0.4, t.height * 0.5, t.height * 0.4)
+        _mat.scale(_scale)
+        mesh.setMatrixAt(i, _mat)
+      }
+      mesh.instanceMatrix.needsUpdate = true
+    },
+    [trees, instanceColorAttr, _mat, _scale],
+  )
+
+  useEffect(() => {
+    return () => {
+      trunkGeo.dispose()
+      canopyGeo.dispose()
+      trunkMat.dispose()
+      canopyMat.dispose()
+    }
+  }, [trunkGeo, canopyGeo, trunkMat, canopyMat])
+
+  const n = trees.length
+  return (
+    <>
+      <instancedMesh ref={setTrunkRef} args={[trunkGeo, trunkMat, n]} frustumCulled />
+      <instancedMesh ref={setCanopyRef} args={[canopyGeo, canopyMat, n]} frustumCulled />
     </>
   )
 }
@@ -236,7 +516,6 @@ function StringLights() {
   const lights = useMemo(() => {
     const arr: { x: number; y: number; z: number }[] = []
 
-    // Create several catenary strings between poles in the tent ring
     for (let s = 0; s < 10; s++) {
       const theta1 = (s / 10) * Math.PI * 2
       const theta2 = ((s + 1) / 10) * Math.PI * 2
@@ -252,7 +531,6 @@ function StringLights() {
         const t = i / bulbCount
         const x = x1 + (x2 - x1) * t
         const z = z1 + (z2 - z1) * t
-        // Catenary sag
         const sag = Math.sin(t * Math.PI) * 8
         const y = 48 - sag
 
@@ -263,12 +541,6 @@ function StringLights() {
     return arr
   }, [])
 
-  // Set instance matrices on mount
-  useMemo(() => {
-    // Will be applied once ref is available via useEffect
-  }, [])
-
-  // Use a separate useEffect won't work in R3F, so apply in useMemo via callback ref
   const setRef = useCallback((mesh: THREE.InstancedMesh | null) => {
     if (!mesh) return
     ;(meshRef as any).current = mesh
@@ -299,7 +571,6 @@ function FunfairDecorations() {
     const arr: { x: number; z: number; type: 'tent' | 'pole' | 'arch' | 'booth' | 'hedge'; color: string; rotation?: number }[] = []
     const colors = ['#ff4444', '#ffaa00', '#4488ff', '#44cc44', '#ff44ff', '#ffffff']
 
-    // Inner ring of tents (original)
     for (let i = 0; i < 12; i++) {
       const theta = (i / 12) * Math.PI * 2
       const r = 400 + Math.random() * 200
@@ -311,7 +582,6 @@ function FunfairDecorations() {
       })
     }
 
-    // Outer tent ring (radius 800–1000)
     for (let i = 0; i < 8; i++) {
       const theta = ((i + 0.5) / 8) * Math.PI * 2
       const r = 800 + Math.random() * 200
@@ -323,7 +593,6 @@ function FunfairDecorations() {
       })
     }
 
-    // Game booths / stalls (radius 150–700)
     for (let i = 0; i < 20; i++) {
       const r = 150 + Math.random() * 550
       const theta = Math.random() * Math.PI * 2
@@ -336,7 +605,6 @@ function FunfairDecorations() {
       })
     }
 
-    // Hedge perimeter (radius ~1100)
     for (let i = 0; i < 40; i++) {
       const theta = (i / 40) * Math.PI * 2
       const r = 1100
@@ -349,7 +617,6 @@ function FunfairDecorations() {
       })
     }
 
-    // Scattered poles with flags
     for (let i = 0; i < 30; i++) {
       const r = 100 + Math.random() * 800
       const theta = Math.random() * Math.PI * 2
@@ -361,7 +628,6 @@ function FunfairDecorations() {
       })
     }
 
-    // Entrance arches
     for (let i = 0; i < 4; i++) {
       const theta = (i / 4) * Math.PI * 2
       arr.push({
@@ -382,12 +648,10 @@ function FunfairDecorations() {
           case 'tent':
             return (
               <group key={i} position={[d.x, 0, d.z]}>
-                {/* Tent body */}
                 <mesh position={[0, 30, 0]}>
                   <coneGeometry args={[25, 40, 6]} />
                   <meshPhongMaterial color={d.color} flatShading />
                 </mesh>
-                {/* Tent base */}
                 <mesh position={[0, 8, 0]}>
                   <cylinderGeometry args={[24, 24, 16, 6]} />
                   <meshPhongMaterial color="#ffffff" flatShading />
@@ -397,17 +661,14 @@ function FunfairDecorations() {
           case 'booth':
             return (
               <group key={i} position={[d.x, 0, d.z]} rotation={[0, d.rotation ?? 0, 0]}>
-                {/* Booth body */}
                 <mesh position={[0, 8, 0]}>
                   <boxGeometry args={[12, 16, 10]} />
                   <meshPhongMaterial color="#f5e6c8" flatShading />
                 </mesh>
-                {/* Awning roof */}
                 <mesh position={[0, 18, 0]}>
                   <boxGeometry args={[14, 3, 12]} />
                   <meshPhongMaterial color={d.color} flatShading />
                 </mesh>
-                {/* Counter */}
                 <mesh position={[0, 5, 5.5]}>
                   <boxGeometry args={[10, 2, 1]} />
                   <meshPhongMaterial color="#8b6914" flatShading />
@@ -430,7 +691,6 @@ function FunfairDecorations() {
                   <cylinderGeometry args={[1, 1, 50, 4]} />
                   <meshPhongMaterial color="#888888" flatShading />
                 </mesh>
-                {/* Flag */}
                 <mesh position={[3, 45, 0]}>
                   <boxGeometry args={[6, 4, 0.5]} />
                   <meshPhongMaterial color={d.color} flatShading />
@@ -440,17 +700,14 @@ function FunfairDecorations() {
           case 'arch':
             return (
               <group key={i} position={[d.x, 0, d.z]}>
-                {/* Left pillar */}
                 <mesh position={[-15, 30, 0]}>
                   <boxGeometry args={[4, 60, 4]} />
                   <meshPhongMaterial color={d.color} flatShading />
                 </mesh>
-                {/* Right pillar */}
                 <mesh position={[15, 30, 0]}>
                   <boxGeometry args={[4, 60, 4]} />
                   <meshPhongMaterial color={d.color} flatShading />
                 </mesh>
-                {/* Top beam */}
                 <mesh position={[0, 62, 0]}>
                   <boxGeometry args={[34, 4, 4]} />
                   <meshPhongMaterial color="#ffdd00" flatShading />
@@ -462,7 +719,6 @@ function FunfairDecorations() {
         }
       })}
 
-      {/* Extra rides */}
       <FerrisWheel position={[-500, 0, 300]} radius={60} />
       <Carousel position={[400, 0, 350]} radius={20} />
     </>

--- a/src/levels/environments/FerrisWheel.tsx
+++ b/src/levels/environments/FerrisWheel.tsx
@@ -9,9 +9,11 @@ interface FerrisWheelProps {
 }
 
 const ROTATION_SPEED = 0.1 // rad/s
+const GONDOLA_COLORS = ['#ff4444', '#4488ff', '#ffcc00', '#44cc44', '#ff44ff', '#ffffff']
 
 /**
- * Animated Ferris wheel: torus frame + radial spokes + hanging gondolas.
+ * Animated Ferris wheel with proper A-frame supports,
+ * thin spokes, and gondolas that hang downward.
  */
 export default function FerrisWheel({
   position = [0, 0, 0],
@@ -19,6 +21,7 @@ export default function FerrisWheel({
   gondolaCount = 12,
 }: FerrisWheelProps) {
   const wheelRef = useRef<THREE.Group>(null)
+  const gondolaRefs = useRef<(THREE.Group | null)[]>([])
 
   const gondolaAngles = useMemo(() => {
     const arr: number[] = []
@@ -28,33 +31,86 @@ export default function FerrisWheel({
     return arr
   }, [gondolaCount])
 
+  // Counter-rotate gondolas so they always hang down
   useFrame((_, delta) => {
     if (wheelRef.current) {
       wheelRef.current.rotation.z += ROTATION_SPEED * delta
+      // Counter-rotate each gondola to keep it upright
+      const wheelAngle = wheelRef.current.rotation.z
+      for (let i = 0; i < gondolaRefs.current.length; i++) {
+        const g = gondolaRefs.current[i]
+        if (g) g.rotation.z = -wheelAngle
+      }
     }
   })
 
+  const hubY = radius + 10 // hub height above ground
+  const legHeight = hubY + 5
+  const legSpread = radius * 0.3
+
   return (
     <group position={position}>
-      {/* Support legs */}
-      <mesh position={[-15, radius * 0.5, 0]} rotation={[0, 0, 0.15]}>
-        <boxGeometry args={[3, radius * 1.1, 3]} />
-        <meshPhongMaterial color="#666666" flatShading />
+      {/* A-frame support legs (front pair) */}
+      <mesh
+        position={[-legSpread * 0.5, legHeight * 0.5, 6]}
+        rotation={[0, 0, Math.atan2(legSpread * 0.5, legHeight)]}
+      >
+        <boxGeometry args={[2.5, legHeight * 1.02, 2.5]} />
+        <meshPhongMaterial color="#555555" flatShading />
       </mesh>
-      <mesh position={[15, radius * 0.5, 0]} rotation={[0, 0, -0.15]}>
-        <boxGeometry args={[3, radius * 1.1, 3]} />
-        <meshPhongMaterial color="#666666" flatShading />
+      <mesh
+        position={[legSpread * 0.5, legHeight * 0.5, 6]}
+        rotation={[0, 0, -Math.atan2(legSpread * 0.5, legHeight)]}
+      >
+        <boxGeometry args={[2.5, legHeight * 1.02, 2.5]} />
+        <meshPhongMaterial color="#555555" flatShading />
       </mesh>
 
-      {/* Rotating wheel */}
-      <group ref={wheelRef} position={[0, radius + 5, 0]}>
-        {/* Outer ring */}
-        <mesh rotation={[Math.PI / 2, 0, 0]}>
-          <torusGeometry args={[radius, 2, 8, 32]} />
+      {/* A-frame support legs (back pair) */}
+      <mesh
+        position={[-legSpread * 0.5, legHeight * 0.5, -6]}
+        rotation={[0, 0, Math.atan2(legSpread * 0.5, legHeight)]}
+      >
+        <boxGeometry args={[2.5, legHeight * 1.02, 2.5]} />
+        <meshPhongMaterial color="#555555" flatShading />
+      </mesh>
+      <mesh
+        position={[legSpread * 0.5, legHeight * 0.5, -6]}
+        rotation={[0, 0, -Math.atan2(legSpread * 0.5, legHeight)]}
+      >
+        <boxGeometry args={[2.5, legHeight * 1.02, 2.5]} />
+        <meshPhongMaterial color="#555555" flatShading />
+      </mesh>
+
+      {/* Cross brace between legs */}
+      <mesh position={[0, legHeight * 0.4, 6]}>
+        <boxGeometry args={[legSpread * 1.2, 1.5, 1.5]} />
+        <meshPhongMaterial color="#444444" flatShading />
+      </mesh>
+      <mesh position={[0, legHeight * 0.4, -6]}>
+        <boxGeometry args={[legSpread * 1.2, 1.5, 1.5]} />
+        <meshPhongMaterial color="#444444" flatShading />
+      </mesh>
+
+      {/* Hub axle */}
+      <mesh position={[0, hubY, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[3, 3, 16, 8]} />
+        <meshPhongMaterial color="#888888" flatShading />
+      </mesh>
+
+      {/* Rotating wheel group */}
+      <group ref={wheelRef} position={[0, hubY, 0]}>
+        {/* Outer rim (two rings for front/back) */}
+        <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0, 4]}>
+          <torusGeometry args={[radius, 1.5, 6, 36]} />
+          <meshPhongMaterial color="#cc3333" flatShading />
+        </mesh>
+        <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, 0, -4]}>
+          <torusGeometry args={[radius, 1.5, 6, 36]} />
           <meshPhongMaterial color="#cc3333" flatShading />
         </mesh>
 
-        {/* Spokes */}
+        {/* Spokes — thin cylinders from center to rim */}
         {gondolaAngles.map((angle, i) => (
           <mesh
             key={`spoke-${i}`}
@@ -63,33 +119,49 @@ export default function FerrisWheel({
               Math.sin(angle) * radius * 0.5,
               0,
             ]}
-            rotation={[0, 0, angle]}
+            rotation={[0, 0, angle + Math.PI / 2]}
           >
-            <boxGeometry args={[radius, 1.5, 1.5]} />
+            <cylinderGeometry args={[0.6, 0.6, radius, 4]} />
             <meshPhongMaterial color="#999999" flatShading />
           </mesh>
         ))}
 
-        {/* Gondolas — counter-rotate so they hang down */}
-        {gondolaAngles.map((angle, i) => {
-          const colors = ['#ff4444', '#4488ff', '#ffcc00', '#44cc44', '#ff44ff', '#ffffff']
-          return (
-            <group
-              key={`gondola-${i}`}
-              position={[
-                Math.cos(angle) * radius,
-                Math.sin(angle) * radius,
-                0,
-              ]}
-            >
-              {/* Gondola cabin */}
-              <mesh position={[0, -8, 0]}>
-                <boxGeometry args={[10, 10, 8]} />
-                <meshPhongMaterial color={colors[i % colors.length]} flatShading />
+        {/* Gondola mounting points + gondolas */}
+        {gondolaAngles.map((angle, i) => (
+          <group
+            key={`gondola-mount-${i}`}
+            position={[
+              Math.cos(angle) * radius,
+              Math.sin(angle) * radius,
+              0,
+            ]}
+          >
+            {/* Cross-bar between the two rim rings */}
+            <mesh rotation={[Math.PI / 2, 0, 0]}>
+              <cylinderGeometry args={[0.8, 0.8, 10, 4]} />
+              <meshPhongMaterial color="#777777" flatShading />
+            </mesh>
+
+            {/* Gondola group — counter-rotated to hang down */}
+            <group ref={(el) => { gondolaRefs.current[i] = el }}>
+              {/* Hanging arm */}
+              <mesh position={[0, -5, 0]}>
+                <cylinderGeometry args={[0.4, 0.4, 6, 4]} />
+                <meshPhongMaterial color="#666666" flatShading />
+              </mesh>
+              {/* Cabin */}
+              <mesh position={[0, -11, 0]}>
+                <boxGeometry args={[7, 6, 5]} />
+                <meshPhongMaterial color={GONDOLA_COLORS[i % GONDOLA_COLORS.length]} flatShading />
+              </mesh>
+              {/* Cabin roof */}
+              <mesh position={[0, -7.5, 0]}>
+                <boxGeometry args={[8, 1, 6]} />
+                <meshPhongMaterial color="#dddddd" flatShading />
               </mesh>
             </group>
-          )
-        })}
+          </group>
+        ))}
       </group>
     </group>
   )

--- a/src/levels/environments/TerrainContext.ts
+++ b/src/levels/environments/TerrainContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+import type { HeightFunction } from '@/utils/terrainNoise'
+
+/** Default height function returns flat ground (y = 0) */
+const defaultHeightFn: HeightFunction = () => 0
+
+/**
+ * React context sharing the terrain height function.
+ * Used by TrackMesh for pillar generation and BiomeEnvironment for trees/decorations.
+ */
+export const TerrainContext = createContext<HeightFunction>(defaultHeightFn)

--- a/src/track/TrackMesh.tsx
+++ b/src/track/TrackMesh.tsx
@@ -1,6 +1,8 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useContext } from 'react'
 import * as THREE from 'three'
 import type { TrackCurve } from './curves/TrackCurve'
+import { TerrainContext } from '@/levels/environments/TerrainContext'
+import type { HeightFunction } from '@/utils/terrainNoise'
 
 interface TrackMeshProps {
   curve: TrackCurve
@@ -150,24 +152,26 @@ function buildTrackGeometry(
   return geometry
 }
 
-/** Generate support pillar positions along the track */
+/** Generate support pillar positions along the track, terrain-aware */
 function generatePillarPositions(
   curve: TrackCurve,
   count: number,
-): { x: number; y: number; z: number; height: number }[] {
-  const pillars: { x: number; y: number; z: number; height: number }[] = []
+  heightFn: HeightFunction,
+): { x: number; groundY: number; z: number; pillarHeight: number }[] {
+  const pillars: { x: number; groundY: number; z: number; pillarHeight: number }[] = []
 
   for (let i = 0; i < count; i++) {
     const t = i / count
     const point = curve.getPointAt(t)
-    const height = point.y
-    // Only place pillars where track is above ground level
-    if (height > 5) {
+    const groundY = heightFn(point.x, point.z)
+    const pillarHeight = point.y - groundY
+    // Only place pillars where track is above terrain
+    if (pillarHeight > 5) {
       pillars.push({
         x: point.x,
-        y: 0,
+        groundY,
         z: point.z,
-        height,
+        pillarHeight,
       })
     }
   }
@@ -176,7 +180,8 @@ function generatePillarPositions(
 }
 
 function TrackPillars({ curve }: { curve: TrackCurve }) {
-  const pillars = useMemo(() => generatePillarPositions(curve, 50), [curve])
+  const heightFn = useContext(TerrainContext)
+  const pillars = useMemo(() => generatePillarPositions(curve, 50, heightFn), [curve, heightFn])
 
   const setRef = useCallback(
     (mesh: THREE.InstancedMesh | null) => {
@@ -186,8 +191,8 @@ function TrackPillars({ curve }: { curve: TrackCurve }) {
 
       for (let i = 0; i < pillars.length; i++) {
         const p = pillars[i]
-        scale.set(1, p.height, 1)
-        mat.makeTranslation(p.x, p.height / 2, p.z)
+        scale.set(1, p.pillarHeight, 1)
+        mat.makeTranslation(p.x, p.groundY + p.pillarHeight / 2, p.z)
         mat.scale(scale)
         mesh.setMatrixAt(i, mat)
       }

--- a/src/utils/terrainNoise.ts
+++ b/src/utils/terrainNoise.ts
@@ -1,0 +1,339 @@
+/**
+ * Simplex noise-based terrain height generation with per-biome configs.
+ * Self-contained 2D simplex noise — no external dependencies.
+ */
+
+import type { BiomeType } from '@/types/level'
+
+// --- 2D Simplex Noise (based on Stefan Gustavson's implementation) ---
+
+const F2 = 0.5 * (Math.sqrt(3) - 1)
+const G2 = (3 - Math.sqrt(3)) / 6
+
+const grad3: [number, number][] = [
+  [1, 1], [-1, 1], [1, -1], [-1, -1],
+  [1, 0], [-1, 0], [0, 1], [0, -1],
+  [1, 1], [-1, 1], [1, -1], [-1, -1],
+]
+
+// Deterministic permutation table (seeded)
+const perm = new Uint8Array(512)
+const permMod12 = new Uint8Array(512)
+
+function seedNoise(seed: number) {
+  const p = new Uint8Array(256)
+  for (let i = 0; i < 256; i++) p[i] = i
+  // Fisher-Yates shuffle with seed
+  let s = seed
+  for (let i = 255; i > 0; i--) {
+    s = (s * 16807 + 0) % 2147483647
+    const j = s % (i + 1)
+    const tmp = p[i]
+    p[i] = p[j]
+    p[j] = tmp
+  }
+  for (let i = 0; i < 512; i++) {
+    perm[i] = p[i & 255]
+    permMod12[i] = perm[i] % 12
+  }
+}
+
+seedNoise(42)
+
+function simplex2(x: number, y: number): number {
+  const s = (x + y) * F2
+  const i = Math.floor(x + s)
+  const j = Math.floor(y + s)
+  const t = (i + j) * G2
+  const X0 = i - t
+  const Y0 = j - t
+  const x0 = x - X0
+  const y0 = y - Y0
+
+  const i1 = x0 > y0 ? 1 : 0
+  const j1 = x0 > y0 ? 0 : 1
+
+  const x1 = x0 - i1 + G2
+  const y1 = y0 - j1 + G2
+  const x2 = x0 - 1 + 2 * G2
+  const y2 = y0 - 1 + 2 * G2
+
+  const ii = i & 255
+  const jj = j & 255
+
+  let n0 = 0, n1 = 0, n2 = 0
+
+  let t0 = 0.5 - x0 * x0 - y0 * y0
+  if (t0 >= 0) {
+    t0 *= t0
+    const gi0 = permMod12[ii + perm[jj]]
+    n0 = t0 * t0 * (grad3[gi0][0] * x0 + grad3[gi0][1] * y0)
+  }
+
+  let t1 = 0.5 - x1 * x1 - y1 * y1
+  if (t1 >= 0) {
+    t1 *= t1
+    const gi1 = permMod12[ii + i1 + perm[jj + j1]]
+    n1 = t1 * t1 * (grad3[gi1][0] * x1 + grad3[gi1][1] * y1)
+  }
+
+  let t2 = 0.5 - x2 * x2 - y2 * y2
+  if (t2 >= 0) {
+    t2 *= t2
+    const gi2 = permMod12[ii + 1 + perm[jj + 1]]
+    n2 = t2 * t2 * (grad3[gi2][0] * x2 + grad3[gi2][1] * y2)
+  }
+
+  // Returns value in [-1, 1]
+  return 70 * (n0 + n1 + n2)
+}
+
+// --- Terrain Config ---
+
+export interface TerrainConfig {
+  /** Noise frequency (lower = larger features) */
+  frequency: number
+  /** Maximum amplitude in world units */
+  amplitude: number
+  /** Number of octaves for fractal detail */
+  octaves: number
+  /** How much each octave's amplitude decreases (0-1) */
+  persistence: number
+  /** Lacunarity: how much each octave's frequency increases */
+  lacunarity: number
+  /** Exponent applied to final height (>1 = sharper peaks, <1 = flatter) */
+  exponent: number
+  /** Use ridge noise (1 - abs(noise)) for sharp peaks */
+  ridgeMode: boolean
+  /** Y offset applied to the entire terrain (e.g. -40 for underwater) */
+  baseY: number
+  /** Radius of flat center valley (track area) */
+  flatRadius: number
+  /** Transition width from flat to full-height terrain */
+  transitionWidth: number
+}
+
+export const BIOME_TERRAIN_CONFIGS: Record<BiomeType, TerrainConfig> = {
+  themePark: {
+    frequency: 0.0008,
+    amplitude: 500,
+    octaves: 5,
+    persistence: 0.45,
+    lacunarity: 2.2,
+    exponent: 1.4,
+    ridgeMode: false,
+    baseY: 0,
+    flatRadius: 600,
+    transitionWidth: 800,
+  },
+  desert: {
+    frequency: 0.001,
+    amplitude: 200,
+    octaves: 3,
+    persistence: 0.4,
+    lacunarity: 2.0,
+    exponent: 1.2,
+    ridgeMode: true,
+    baseY: 0,
+    flatRadius: 600,
+    transitionWidth: 600,
+  },
+  ocean: {
+    frequency: 0.0007,
+    amplitude: 300,
+    octaves: 4,
+    persistence: 0.5,
+    lacunarity: 2.3,
+    exponent: 1.8,
+    ridgeMode: false,
+    baseY: -40,
+    flatRadius: 600,
+    transitionWidth: 700,
+  },
+  arctic: {
+    frequency: 0.0006,
+    amplitude: 600,
+    octaves: 6,
+    persistence: 0.5,
+    lacunarity: 2.1,
+    exponent: 1.3,
+    ridgeMode: true,
+    baseY: 0,
+    flatRadius: 600,
+    transitionWidth: 900,
+  },
+}
+
+/** Desert gets an extra macro-scale mesa layer */
+function mesaNoise(x: number, z: number): number {
+  const n = simplex2(x * 0.0003, z * 0.0003)
+  // Step function: flat tops when noise > threshold
+  const mesa = Math.max(0, n - 0.2) * 2.5
+  return Math.min(mesa, 1) * 150
+}
+
+export type HeightFunction = (x: number, z: number) => number
+
+/** Pre-sampled track point for terrain suppression */
+interface TrackSample {
+  x: number
+  y: number
+  z: number
+}
+
+/** Hard clamp radius — terrain is always forced below track here */
+const TRACK_HARD_RADIUS = 40
+/** Soft blend radius — terrain transitions from suppressed to natural */
+const TRACK_SOFT_RADIUS = 120
+/** Extra clearance below the track */
+const TRACK_CLEARANCE = 15
+
+/**
+ * Pre-sample a track curve to build a lookup table for terrain suppression.
+ * Uses a simple interface so we don't import Three.js types here.
+ */
+export function sampleTrackPath(
+  getPointAt: (t: number) => { x: number; y: number; z: number },
+  sampleCount = 500,
+): TrackSample[] {
+  const samples: TrackSample[] = []
+  for (let i = 0; i < sampleCount; i++) {
+    const t = i / sampleCount
+    const p = getPointAt(t)
+    samples.push({ x: p.x, y: p.y, z: p.z })
+  }
+  return samples
+}
+
+/**
+ * Creates a height function for the given biome terrain config.
+ * If trackSamples is provided, terrain is suppressed near the track path
+ * so the coaster never goes underground.
+ */
+export function createHeightFunction(
+  biome: BiomeType,
+  trackSamples?: TrackSample[],
+): HeightFunction {
+  const config = BIOME_TERRAIN_CONFIGS[biome]
+
+  return (x: number, z: number): number => {
+    const dist = Math.sqrt(x * x + z * z)
+
+    // Distance-based amplitude envelope: flat center, rising to full at edges
+    let envelope: number
+    if (dist < config.flatRadius) {
+      envelope = 0
+    } else if (dist < config.flatRadius + config.transitionWidth) {
+      const t = (dist - config.flatRadius) / config.transitionWidth
+      // Smooth ease-in curve
+      envelope = t * t * (3 - 2 * t)
+    } else {
+      envelope = 1
+    }
+
+    // Multi-octave fractal noise
+    let value = 0
+    let amp = 1
+    let freq = config.frequency
+    let maxAmp = 0
+
+    for (let o = 0; o < config.octaves; o++) {
+      let n = simplex2(x * freq, z * freq)
+
+      if (config.ridgeMode) {
+        // Ridge noise: sharp peaks
+        n = 1 - Math.abs(n)
+        n = n * n // Sharpen ridges
+      } else {
+        // Regular noise: remap from [-1,1] to [0,1]
+        n = (n + 1) * 0.5
+      }
+
+      value += n * amp
+      maxAmp += amp
+      amp *= config.persistence
+      freq *= config.lacunarity
+    }
+
+    // Normalize to [0, 1]
+    value /= maxAmp
+
+    // Apply exponent for peak sharpness
+    value = Math.pow(value, config.exponent)
+
+    // Apply envelope and amplitude
+    let height = value * config.amplitude * envelope + config.baseY
+
+    // Desert mesa overlay
+    if (biome === 'desert') {
+      height += mesaNoise(x, z) * envelope
+    }
+
+    // Ensure flat center stays at base level
+    if (envelope === 0) {
+      height = config.baseY
+    }
+
+    // --- Track corridor suppression ---
+    // Find the lowest track Y among all nearby samples, then suppress terrain below it.
+    // Two zones: hard clamp (inner) and smooth blend (outer).
+    if (trackSamples) {
+      const softR2 = TRACK_SOFT_RADIUS * TRACK_SOFT_RADIUS
+      let minDist2D = Infinity
+      let lowestTrackY = Infinity
+
+      for (let i = 0; i < trackSamples.length; i++) {
+        const s = trackSamples[i]
+        const dx = x - s.x
+        const dz = z - s.z
+        const d2 = dx * dx + dz * dz
+        if (d2 < softR2) {
+          // Track the closest point AND the lowest track Y within range
+          if (d2 < minDist2D) {
+            minDist2D = d2
+          }
+          if (s.y < lowestTrackY) {
+            lowestTrackY = s.y
+          }
+        }
+      }
+
+      if (minDist2D < softR2) {
+        const dist2D = Math.sqrt(minDist2D)
+        const maxAllowed = lowestTrackY - TRACK_CLEARANCE
+
+        if (height > maxAllowed) {
+          if (dist2D < TRACK_HARD_RADIUS) {
+            // Hard zone: always clamp
+            height = maxAllowed
+          } else {
+            // Soft zone: smooth blend from clamped to natural
+            const blend = (dist2D - TRACK_HARD_RADIUS) / (TRACK_SOFT_RADIUS - TRACK_HARD_RADIUS)
+            const smoothBlend = blend * blend * (3 - 2 * blend)
+            height = maxAllowed + (height - maxAllowed) * smoothBlend
+          }
+        }
+      }
+    }
+
+    return height
+  }
+}
+
+/**
+ * Compute terrain slope at a point (for slope-based coloring and tree rejection).
+ * Returns slope angle in radians (0 = flat, PI/2 = vertical).
+ */
+export function getTerrainSlope(
+  heightFn: HeightFunction,
+  x: number,
+  z: number,
+  delta = 5,
+): number {
+  const h = heightFn(x, z)
+  const hx = heightFn(x + delta, z)
+  const hz = heightFn(x, z + delta)
+  const dx = (hx - h) / delta
+  const dz = (hz - h) / delta
+  return Math.atan(Math.sqrt(dx * dx + dz * dz))
+}


### PR DESCRIPTION
**Summary:**
Replace flat/random ground planes with noise-based procedural terrain generation. Each biome now has dramatic mountains, vertex-colored landscapes, and unique decorations. Track corridor carving prevents the coaster from intersecting terrain.

**Changes:**
- Added `src/utils/terrainNoise.ts` — simplex noise height generation with per-biome configs and track-aware suppression
- Added `src/levels/environments/TerrainContext.ts` — React context sharing the height function
- Added `src/levels/environments/BiomeDecorations.tsx` — InstancedMesh decorations for desert, ocean, and arctic biomes
- Overhauled `BiomeEnvironment.tsx` — 128x128 noise terrain with vertex coloring by altitude/slope, terrain-aware trees with slope rejection
- Updated `TrackMesh.tsx` — pillars now span from terrain surface to track instead of assuming y=0
- Updated `SceneManager.tsx` — wraps level scene with TerrainContext provider, passes track samples for corridor carving
- Rebuilt `FerrisWheel.tsx` — proper A-frame supports, thin spoke cylinders, counter-rotating gondolas