### PR TITLE
fix: stabilize replay flow and clean up runtime state

### DIFF
--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -33,3 +33,4 @@ export function syncVolumes(): void {
     musicChannel.volume.value = Tone.gainToDb(musicVolume)
   }
 }
+

--- a/src/audio/MusicManager.ts
+++ b/src/audio/MusicManager.ts
@@ -122,6 +122,24 @@ let leadLoop: Tone.Sequence | null = null
 let currentIntensity = 0
 let isPlaying = false
 
+function resetMusicState() {
+  padLoop?.dispose(); padLoop = null
+  bassLoop?.dispose(); bassLoop = null
+  percLoop?.dispose(); percLoop = null
+  leadLoop?.dispose(); leadLoop = null
+
+  padSynth?.dispose(); padSynth = null
+  bassSynth?.dispose(); bassSynth = null
+  percSynth?.dispose(); percSynth = null
+  leadSynth?.dispose(); leadSynth = null
+
+  const transport = Tone.getTransport()
+  transport.stop()
+  transport.cancel()
+  isPlaying = false
+  currentIntensity = 0
+}
+
 // ── Instrument setup ───────────────────────────────────────────
 
 function createInstruments() {
@@ -221,22 +239,7 @@ export function startMusic(biome: BiomeType = 'themePark'): void {
 
 export function stopMusic(): void {
   if (!isPlaying) return
-
-  padLoop?.dispose(); padLoop = null
-  bassLoop?.dispose(); bassLoop = null
-  percLoop?.dispose(); percLoop = null
-  leadLoop?.dispose(); leadLoop = null
-
-  padSynth?.dispose(); padSynth = null
-  bassSynth?.dispose(); bassSynth = null
-  percSynth?.dispose(); percSynth = null
-  leadSynth?.dispose(); leadSynth = null
-
-  const transport = Tone.getTransport()
-  transport.stop()
-  transport.cancel()
-  isPlaying = false
-  currentIntensity = 0
+  resetMusicState()
 }
 
 export function setMusicIntensity(intensity: number): void {
@@ -249,3 +252,4 @@ export function setMusicIntensity(intensity: number): void {
 export function getMusicIntensity(): number {
   return currentIntensity
 }
+

--- a/src/audio/SFXManager.ts
+++ b/src/audio/SFXManager.ts
@@ -136,3 +136,4 @@ export function playExplosionSound(comboCount: number = 0): void {
   const pingFreq = 1400 + Math.min(comboCount, 10) * 80 + Math.random() * 300
   popPing!.triggerAttackRelease(pingFreq, 0.04, toneNow)
 }
+

--- a/src/audio/TitleMusicManager.ts
+++ b/src/audio/TitleMusicManager.ts
@@ -24,6 +24,25 @@ let bassLoop: Tone.Sequence | null = null
 let chimeLoop: Tone.Loop | null = null
 let tambLoop: Tone.Sequence | null = null
 
+function resetTitleMusicState() {
+  melodyLoop?.dispose(); melodyLoop = null
+  padLoop?.dispose(); padLoop = null
+  bassLoop?.dispose(); bassLoop = null
+  chimeLoop?.dispose(); chimeLoop = null
+  tambLoop?.dispose(); tambLoop = null
+
+  melodyBox?.dispose(); melodyBox = null
+  padSynth?.dispose(); padSynth = null
+  bassSynth?.dispose(); bassSynth = null
+  chimeSynth?.dispose(); chimeSynth = null
+  tamb?.dispose(); tamb = null
+
+  const transport = Tone.getTransport()
+  transport.stop()
+  transport.cancel()
+  isPlaying = false
+}
+
 // — Melody: music-box calliope feel, 2-bar phrase ————————————
 const melodyNotes = [
   // Bar 1 — ascending, bouncy
@@ -189,27 +208,10 @@ export function startTitleMusic(): void {
 
 export function stopTitleMusic(): void {
   if (!isPlaying) return
-
-  // Dispose loops so they don't conflict with game music on the shared transport
-  melodyLoop?.dispose(); melodyLoop = null
-  padLoop?.dispose(); padLoop = null
-  bassLoop?.dispose(); bassLoop = null
-  chimeLoop?.dispose(); chimeLoop = null
-  tambLoop?.dispose(); tambLoop = null
-
-  // Dispose synths so they can be re-created fresh next time
-  melodyBox?.dispose(); melodyBox = null
-  padSynth?.dispose(); padSynth = null
-  bassSynth?.dispose(); bassSynth = null
-  chimeSynth?.dispose(); chimeSynth = null
-  tamb?.dispose(); tamb = null
-
-  const transport = Tone.getTransport()
-  transport.stop()
-  transport.cancel()
-  isPlaying = false
+  resetTitleMusicState()
 }
 
 export function isTitleMusicPlaying(): boolean {
   return isPlaying
 }
+

--- a/src/canvas/GameTimer.tsx
+++ b/src/canvas/GameTimer.tsx
@@ -16,10 +16,12 @@ export default function GameTimer({ seconds }: GameTimerProps) {
   const lastCeiled = useRef<number>(-1)
 
   useEffect(() => {
-    startTime.current = null
-    lastCeiled.current = -1
-    setTimeRemaining(seconds)
-  }, [seconds, setTimeRemaining])
+    if (phase === 'playing') {
+      startTime.current = null
+      lastCeiled.current = -1
+      setTimeRemaining(seconds)
+    }
+  }, [phase, seconds, setTimeRemaining])
 
   useFrame(({ clock }) => {
     if (phase !== 'playing') return

--- a/src/canvas/TitleScene.tsx
+++ b/src/canvas/TitleScene.tsx
@@ -278,15 +278,28 @@ function Balloons() {
 
   const [pops, setPops] = useState<{ id: number; pos: THREE.Vector3; color: string }[]>([])
   const popId = useRef(0)
+  const timeoutIdsRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  const rafIdsRef = useRef<number[]>([])
 
   const handlePop = useCallback((worldPos: THREE.Vector3, color: string) => {
     const id = popId.current++
     // Defer adding the pop burst to the next frame so the click frame stays light
     // and we avoid layout/jank from synchronous heavy re-render
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       setPops((prev) => [...prev, { id, pos: worldPos.clone(), color }])
-      setTimeout(() => setPops((prev) => prev.filter((p) => p.id !== id)), 700)
+      const timeoutId = setTimeout(() => setPops((prev) => prev.filter((p) => p.id !== id)), 700)
+      timeoutIdsRef.current.push(timeoutId)
     })
+    rafIdsRef.current.push(rafId)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      for (const timeoutId of timeoutIdsRef.current) clearTimeout(timeoutId)
+      timeoutIdsRef.current = []
+      for (const rafId of rafIdsRef.current) cancelAnimationFrame(rafId)
+      rafIdsRef.current = []
+    }
   }, [])
 
   return (

--- a/src/combat/CollisionManager.ts
+++ b/src/combat/CollisionManager.ts
@@ -21,3 +21,9 @@ export function unregisterCollisionTarget(id: string): void {
 export function getCollisionTargets(): Map<string, CollisionTarget> {
   return targets
 }
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    targets.clear()
+  })
+}

--- a/src/combat/projectiles/BulletPool.tsx
+++ b/src/combat/projectiles/BulletPool.tsx
@@ -1,33 +1,15 @@
-import { useRef, useMemo, useCallback } from 'react'
-import { useFrame, useThree } from '@react-three/fiber'
+import { useRef, useMemo, useCallback, useEffect } from 'react'
+import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { useGameStore } from '@/store/useGameStore'
 import { getCollisionTargets } from '@/combat/CollisionManager'
+import type { Bullet, BulletPoolHandle } from './bulletPoolHandle'
+import { setBulletPool } from './bulletPoolHandle'
 
 const POOL_SIZE = 350
 const FIRE_DELAY_MS = 100
 const BULLET_LIFETIME_MS = 5000
 const BULLET_SPEED = 8
-
-interface Bullet {
-  alive: boolean
-  bornAt: number
-  position: THREE.Vector3
-  direction: THREE.Vector3
-  speed: number
-}
-
-interface BulletPoolHandle {
-  fire: (origin: THREE.Vector3, direction: THREE.Vector3) => void
-  getLiveBullets: () => Bullet[]
-  getLiveBulletCount: () => number
-}
-
-// Singleton ref for external access
-let poolHandle: BulletPoolHandle | null = null
-export function getBulletPool(): BulletPoolHandle | null {
-  return poolHandle
-}
 
 interface BulletPoolProps {
   bulletSize?: number
@@ -95,8 +77,10 @@ export default function BulletPool({
   const getLiveBullets = useCallback(() => liveBulletBuffer.current, [])
   const getLiveBulletCount = useCallback(() => liveBulletCount.current, [])
 
-  // Expose the pool handle
-  poolHandle = { fire, getLiveBullets, getLiveBulletCount }
+  useEffect(() => {
+    setBulletPool({ fire, getLiveBullets, getLiveBulletCount })
+    return () => setBulletPool(null)
+  }, [fire, getLiveBullets, getLiveBulletCount])
 
   useFrame(() => {
     if (!meshRef.current || phase !== 'playing') return

--- a/src/combat/projectiles/bulletPoolHandle.ts
+++ b/src/combat/projectiles/bulletPoolHandle.ts
@@ -1,0 +1,31 @@
+import type * as THREE from 'three'
+
+export interface Bullet {
+  alive: boolean
+  bornAt: number
+  position: THREE.Vector3
+  direction: THREE.Vector3
+  speed: number
+}
+
+export interface BulletPoolHandle {
+  fire: (origin: THREE.Vector3, direction: THREE.Vector3) => void
+  getLiveBullets: () => Bullet[]
+  getLiveBulletCount: () => number
+}
+
+let poolHandle: BulletPoolHandle | null = null
+
+export function setBulletPool(handle: BulletPoolHandle | null): void {
+  poolHandle = handle
+}
+
+export function getBulletPool(): BulletPoolHandle | null {
+  return poolHandle
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    poolHandle = null
+  })
+}

--- a/src/combat/useShooting.ts
+++ b/src/combat/useShooting.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef } from 'react'
 import { useThree } from '@react-three/fiber'
 import * as THREE from 'three'
-import { getBulletPool } from './projectiles/BulletPool'
+import { getBulletPool } from './projectiles/bulletPoolHandle'
 import { useGameStore } from '@/store/useGameStore'
 import { playFireSound } from '@/audio/SFXManager'
 

--- a/src/core/EventBus.ts
+++ b/src/core/EventBus.ts
@@ -25,3 +25,9 @@ class EventBus {
 }
 
 export const eventBus = new EventBus()
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    eventBus.clear()
+  })
+}

--- a/src/effects/ParticleExplosion.tsx
+++ b/src/effects/ParticleExplosion.tsx
@@ -1,7 +1,8 @@
-import { useRef, useMemo } from 'react'
+import { useRef, useMemo, useEffect } from 'react'
 import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { randomRange, randomRangeLow } from '@/utils/math'
+import { setExplosionPool } from './explosionPoolHandle'
 
 const POOL_SLOTS = 5
 const FIRE_COUNT = 30
@@ -22,15 +23,6 @@ interface ExplosionSlot {
   fireVelocities: THREE.Vector3[]
   sparkPositions: THREE.Vector3[]
   sparkVelocities: THREE.Vector3[]
-}
-
-interface ExplosionPoolHandle {
-  activate: (position: THREE.Vector3, color: string) => void
-}
-
-let poolHandle: ExplosionPoolHandle | null = null
-export function getExplosionPool(): ExplosionPoolHandle | null {
-  return poolHandle
 }
 
 function createSlot(): ExplosionSlot {
@@ -125,7 +117,10 @@ export default function ParticleExplosionPool() {
     [slots, fireMats],
   )
 
-  poolHandle = { activate }
+  useEffect(() => {
+    setExplosionPool({ activate })
+    return () => setExplosionPool(null)
+  }, [activate])
 
   useFrame(() => {
     const now = performance.now()

--- a/src/effects/ScorePopups.tsx
+++ b/src/effects/ScorePopups.tsx
@@ -23,6 +23,8 @@ export default function ScorePopups() {
   const [popups, setPopups] = useState<ScorePopup[]>([])
   const pendingRef = useRef<ScorePopup[]>([])
   const flushScheduled = useRef(false)
+  const timeoutIdsRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  const mountedRef = useRef(true)
 
   const handleKill = useCallback((data: unknown) => {
     const { screenX, screenY, combo, score } = data as {
@@ -36,14 +38,17 @@ export default function ScorePopups() {
     pendingRef.current.push({ id, score, combo, screenX, screenY })
 
     // Schedule removal
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
+      if (!mountedRef.current) return
       setPopups((prev) => prev.filter((p) => p.id !== id))
     }, 1000)
+    timeoutIdsRef.current.push(timeoutId)
 
     // Batch: flush pending popups once per microtask
     if (!flushScheduled.current) {
       flushScheduled.current = true
       queueMicrotask(() => {
+        if (!mountedRef.current) return
         const batch = pendingRef.current
         pendingRef.current = []
         flushScheduled.current = false
@@ -57,7 +62,14 @@ export default function ScorePopups() {
 
   useEffect(() => {
     eventBus.on('enemy:killed:screen', handleKill)
-    return () => eventBus.off('enemy:killed:screen', handleKill)
+    return () => {
+      mountedRef.current = false
+      for (const timeoutId of timeoutIdsRef.current) clearTimeout(timeoutId)
+      timeoutIdsRef.current = []
+      pendingRef.current = []
+      flushScheduled.current = false
+      eventBus.off('enemy:killed:screen', handleKill)
+    }
   }, [handleKill])
 
   return (

--- a/src/effects/explosionPoolHandle.ts
+++ b/src/effects/explosionPoolHandle.ts
@@ -1,0 +1,21 @@
+import type * as THREE from 'three'
+
+export interface ExplosionPoolHandle {
+  activate: (position: THREE.Vector3, color: string) => void
+}
+
+let poolHandle: ExplosionPoolHandle | null = null
+
+export function setExplosionPool(handle: ExplosionPoolHandle | null): void {
+  poolHandle = handle
+}
+
+export function getExplosionPool(): ExplosionPoolHandle | null {
+  return poolHandle
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    poolHandle = null
+  })
+}

--- a/src/entities/spawning/EnemySpawner.tsx
+++ b/src/entities/spawning/EnemySpawner.tsx
@@ -8,7 +8,7 @@ import Crow from '../enemies/Crow'
 import Shark from '../enemies/Shark'
 import Snowman from '../enemies/Snowman'
 import GoldenBalloon from '../enemies/GoldenBalloon'
-import { getExplosionPool } from '@/effects/ParticleExplosion'
+import { getExplosionPool } from '@/effects/explosionPoolHandle'
 
 interface EnemySpawnerProps {
   waves: EnemyWave[]
@@ -159,6 +159,7 @@ export default function EnemySpawner({ waves }: EnemySpawnerProps) {
   )
   const waveKillCounts = useRef<number[]>(waves.map(() => 0))
   const waveTimers = useRef<ReturnType<typeof setTimeout>[]>([])
+  const slowMoResetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Track killed enemies per wave
   const killedEnemies = useRef(new Set<string>())
@@ -184,7 +185,13 @@ export default function EnemySpawner({ waves }: EnemySpawnerProps) {
 
   // Clean up timers
   useEffect(() => {
-    return () => waveTimers.current.forEach(clearTimeout)
+    return () => {
+      waveTimers.current.forEach(clearTimeout)
+      waveTimers.current = []
+      if (slowMoResetTimer.current) clearTimeout(slowMoResetTimer.current)
+      slowMoResetTimer.current = null
+      killedEnemies.current.clear()
+    }
   }, [])
 
   const onKill = useCallback(
@@ -224,7 +231,8 @@ export default function EnemySpawner({ waves }: EnemySpawnerProps) {
       if (killedEnemies.current.size >= totalEnemyCount) {
         const store = useGameStore.getState()
         store.setTimeScale(0.1)
-        setTimeout(() => {
+        if (slowMoResetTimer.current) clearTimeout(slowMoResetTimer.current)
+        slowMoResetTimer.current = setTimeout(() => {
           useGameStore.getState().setTimeScale(1)
         }, 1500)
       }

--- a/src/track/TrackMesh.tsx
+++ b/src/track/TrackMesh.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useContext } from 'react'
+import { useMemo, useCallback, useContext, useEffect, useRef } from 'react'
 import * as THREE from 'three'
 import type { TrackCurve } from './curves/TrackCurve'
 import { TerrainContext } from '@/levels/environments/TerrainContext'
@@ -182,12 +182,12 @@ function generatePillarPositions(
 function TrackPillars({ curve }: { curve: TrackCurve }) {
   const heightFn = useContext(TerrainContext)
   const pillars = useMemo(() => generatePillarPositions(curve, 50, heightFn), [curve, heightFn])
+  const mat = useRef(new THREE.Matrix4()).current
+  const scale = useRef(new THREE.Vector3()).current
 
   const setRef = useCallback(
     (mesh: THREE.InstancedMesh | null) => {
       if (!mesh) return
-      const mat = new THREE.Matrix4()
-      const scale = new THREE.Vector3()
 
       for (let i = 0; i < pillars.length; i++) {
         const p = pillars[i]
@@ -221,6 +221,12 @@ export default function TrackMesh({
     () => buildTrackGeometry(curve, segments, color1, color2),
     [curve, segments, color1, color2],
   )
+
+  useEffect(() => {
+    return () => {
+      geometry.dispose()
+    }
+  }, [geometry])
 
   return (
     <>

--- a/src/ui/hud/WaveAnnouncement.tsx
+++ b/src/ui/hud/WaveAnnouncement.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { eventBus } from '@/core/EventBus'
 
@@ -7,14 +7,20 @@ import { eventBus } from '@/core/EventBus'
  */
 export default function WaveAnnouncement() {
   const [text, setText] = useState<string | null>(null)
+  const clearTextTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     const handler = (label: unknown) => {
       setText(label as string)
-      setTimeout(() => setText(null), 2000)
+      if (clearTextTimeoutRef.current) clearTimeout(clearTextTimeoutRef.current)
+      clearTextTimeoutRef.current = setTimeout(() => setText(null), 2000)
     }
     eventBus.on('wave:announce', handler)
-    return () => eventBus.off('wave:announce', handler)
+    return () => {
+      if (clearTextTimeoutRef.current) clearTimeout(clearTextTimeoutRef.current)
+      clearTextTimeoutRef.current = null
+      eventBus.off('wave:announce', handler)
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- Fix replay flow by resetting `GameTimer` state whenever phase re-enters `playing`, preventing instant bounce back to results.
- Add cleanup for timeout/animation callbacks in popup/announcement/title effects to avoid stale updates after unmount.
- Split bullet/explosion pool handles into dedicated modules and clear HMR-sensitive singleton maps/listeners to reduce stale runtime state in long dev sessions.

## Test plan
- [x] Run `npm run build`
- [x] Complete a level and click `Replay`; verify timer restarts and gameplay resumes normally
- [x] Play a level and return/replay repeatedly; verify no immediate phase regressions or duplicate UI behaviors
- [x] Capture heap snapshots (A/B/C); confirm growth trends toward plateau rather than runaway linear increase

Made with [Cursor](https://cursor.com)